### PR TITLE
update example 6 with passthrough secret generator

### DIFF
--- a/apps/podinfo/ex6-helmrelease-from-gitrepo-with-gitvalues/helmrelease.yaml
+++ b/apps/podinfo/ex6-helmrelease-from-gitrepo-with-gitvalues/helmrelease.yaml
@@ -16,6 +16,8 @@ spec:
   timeout: 1m0s
   releaseName: podinfo
   serviceAccountName: ex6
+  values:
+    secretName: podinfo-values # for example
   valuesFrom:
     - kind: ConfigMap
       name: podinfo-values

--- a/apps/podinfo/ex6-helmrelease-from-gitrepo-with-gitvalues/kustomizeconfig.yaml
+++ b/apps/podinfo/ex6-helmrelease-from-gitrepo-with-gitvalues/kustomizeconfig.yaml
@@ -4,3 +4,5 @@ nameReference:
   fieldSpecs:
   - path: spec/valuesFrom/name
     kind: HelmRelease
+  - path: spec/values/secretName
+    kind: HelmRelease


### PR DESCRIPTION
So I have mixed up configmaps and secrets in this example, and I'm not really using `secretName` for anything within the HelmRelease, but this is an example that shows how to pass a generated name into a helmrelease for use in a template later.